### PR TITLE
Make `pyeqeq` optional extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,17 @@ Development version:
 pip install git+https://github.com/Au-4/mofchecker_2.0
 ```
 
-Note that you need to install [zeopp](https://anaconda.org/conda-forge/zeopp-lsmo) if you want to use the porosity features.
+### Optional Dependencies
+
+**For charge checking features:**
+To enable the `no_high_charges` computation, install with the optional `pyeqeq` package:
+
+```bash
+pip install "mofchecker[pyeqeq] @ git+https://github.com/Au-4/mofchecker_2.0.git"
+```
+
+**For porosity analysis:**
+To use porosity features, install [zeopp](https://anaconda.org/conda-forge/zeopp-lsmo):
 
 ```bash
 conda install -c conda-forge zeopp-lsmo

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     install_requires=[
-        "pyeqeq",
         "click",
         "networkx>=2.5",
         "backports.cached-property",
@@ -26,6 +25,11 @@ setup(
         "libconeangle",
         "psutil"
     ],
+    extras_require={
+        "pyeqeq": [
+            "pyeqeq"
+        ]
+    },
     entry_points={
         "console_scripts": [
             "mofchecker=mofchecker.cli:run",


### PR DESCRIPTION
Currently, `pyeqeq` build fails with python>3.10 due to their build dependence on `pybind==2.6.1` that is not compatible. This subsequently causes issues with installing MOFChecker for newer versions of python.

The `pyeqeq` package is only used in (optional) charge calculations:
https://github.com/Au-4/mofchecker_2.0/blob/c3ab4c154648f764dfdffcd1336ccc30e7bf07df/src/mofchecker/checks/charge_check.py#L35-L47

This means that if we make `pyeqeq` an optional extra, it allows installing MOFChecker with python>3.10. 