### PR TITLE
Update README.md to run `.checks()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ results = []
 
 for structure in sample_structures:
     mofchecker = MOFChecker.from_cif(structure)
-    results.append(mofchecker.get_mof_descriptors())
+    results.append(mofchecker.checks())
 ```
 Checking and cleaning cases can be found in tests folder.
 The positive charge of metal site can be obtained from Oximachine (https://github.com/kjappelbaum/oximachinerunner)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ results = []
 
 for structure in sample_structures:
     mofchecker = MOFChecker.from_cif(structure)
-    results.append(mofchecker.checks())
+    results.append(mofchecker.checks)
 ```
 Checking and cleaning cases can be found in tests folder.
 The positive charge of metal site can be obtained from Oximachine (https://github.com/kjappelbaum/oximachinerunner)


### PR DESCRIPTION
The README right now is showcase `mofchecker.get_mof_descriptors()`, but most people are probably interested in the check results, e.g. `.checks`. I have updated the README accordingly.